### PR TITLE
Feature/refactor opportunity navision customer country logic

### DIFF
--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -1,8 +1,10 @@
 public with sharing class UpsertContractOnAwardedOpportunities implements TriggerAction.BeforeUpdate{
 
-	public static void beforeUpdate(List<SObject> oldOpportunities, List<SObject> newOpportunities) {
-		Map<Id, Opportunity> oldOpportunitiesByIds = new Map<Id, Opportunity>((List<Opportunity>) oldOpportunities);
-		for (Opportunity opportunity: (List<Opportunity>) newOpportunities){
+	public void beforeUpdate(List<Opportunity> newOpportunities, List<Opportunity> oldOpportunities) {
+		Logger.debug('UpsertContractOnAwardedOpportunities - Before Update');
+		Map<Id, Opportunity> oldOpportunitiesByIds = new Map<Id, Opportunity>(oldOpportunities);
+		Formula.recalculateFormulas(newOpportunities); // To ensure that Navision_Account_in_Owners_Country__c is up to date
+		for (Opportunity opportunity:newOpportunities){
 			Opportunity newOpportunity=opportunity;
 			Opportunity oldOpportunity=oldOpportunitiesByIds.get(newOpportunity.Id);
 
@@ -13,7 +15,7 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 			if(
 				newOpportunity.New_Or_Renewal__c == 'New' &&
 				String.isBlank(newOpportunity.ContractServiceNowUrl__c) &&
-				doesOpportunityOwnerCountryMatchNavisionCustomerCountry(oldOpportunity, newOpportunity)
+				newOpportunity.Navision_Account_in_Owners_Country__c
 			){
 				System.enqueueJob(new ServiceNowUploadContractsQueueable(newOpportunity));
 				Logger.info('Contract is created in ServiceNow for this Opportunity', newOpportunity).addTag('Opportunity trigger handler service');
@@ -21,6 +23,10 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 				Logger.info('Contract is not created is ServiceNow for this Opportunity', newOpportunity).addTag('Opportunity trigger handler service');
 				Logger.info('New or renewal: ' + newOpportunity.New_Or_Renewal__c).addTag('Opportunity trigger handler service');
 				Logger.info('Service Now contract url: ' + newOpportunity.ContractServiceNowUrl__c).addTag('Opportunity trigger handler service');
+				if (!newOpportunity.Navision_Account_in_Owners_Country__c) {
+					Logger.error('Opportunity Owner Country: "'+opportunity.Owner_Country__c+'" does not match the Account\'s Country in Navision').addTag('Opportunity trigger handler service');
+				}
+
 			}
 		}
 		Logger.saveLog();
@@ -28,30 +34,5 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 
 	public static Boolean hasOpportunityStageChangedToAwarded(Opportunity oldOpportunity, Opportunity newOpportunity){
 		return (newOpportunity.StageName == Utils.AWARDED && newOpportunity.StageName != oldOpportunity.StageName);
-	}
-
-	public static Boolean doesOpportunityOwnerCountryMatchNavisionCustomerCountry(Opportunity oldOpportunity, Opportunity newOpportunity){
-		Boolean hasNavisionCustomerChanged =
-				(newOpportunity.Navision_Customer_NO__c != oldOpportunity.Navision_Customer_NO__c) ||
-						(newOpportunity.Navision_Customer_SE__c != oldOpportunity.Navision_Customer_SE__c) ||
-						(newOpportunity.Navision_Customer_DK__c != oldOpportunity.Navision_Customer_DK__c);
-		Logger.debug('hasNavisionCustomerChanged: ' + hasNavisionCustomerChanged, newOpportunity).addTag('Opportunity trigger handler service');
-
-		Boolean doesOwnerCountryMatchCountryInNavision =
-				(newOpportunity.Owner_Country__c == 'Norway' && newOpportunity.Navision_Customer_NO__c) ||
-						(newOpportunity.Owner_Country__c == 'Sweden' && newOpportunity.Navision_Customer_SE__c) ||
-						(newOpportunity.Owner_Country__c == 'Denmark' && newOpportunity.Navision_Customer_DK__c);
-		Logger.debug('doesOwnerCountryMatchCountryInNavision: ' + doesOwnerCountryMatchCountryInNavision, newOpportunity).addTag('Opportunity trigger handler service');
-		Logger.debug('Navision_Account_in_Owners_Country__c value on opportunity: ' + newOpportunity.Navision_Account_in_Owners_Country__c.toString(), newOpportunity).addTag('Opportunity trigger handler service');
-
-		if (newOpportunity.Navision_Account_in_Owners_Country__c!=doesOwnerCountryMatchCountryInNavision) {
-			Logger.warn('Navision_Account_in_Owners_Country__c does not match doesOwnerCountryMatchCountryInNavision!',newOpportunity).addTag('Opportunity trigger handler service');
-			Formula.recalculateFormulas(new List<Opportunity>{newOpportunity});
-			Logger.debug('Navision_Account_in_Owners_Country__c after Formula recalculation: ' +newOpportunity.Navision_Account_in_Owners_Country__c, newOpportunity).addTag('Opportunity trigger handler service');
-		}
-
-		return newOpportunity.Navision_Account_in_Owners_Country__c ||
-				(doesOwnerCountryMatchCountryInNavision &&
-						hasNavisionCustomerChanged);
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -7,7 +7,6 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 		Map<Id, Opportunity> oldOpportunitiesByIds = new Map<Id, Opportunity>(oldOpportunities);
 		parentAccountsByIds = getAccountByIdsFromChildOpportunities(newOpportunities);
 
-		Formula.recalculateFormulas(newOpportunities); // To ensure that Navision_Account_in_Owners_Country__c is up to date
 		for (Opportunity opportunity:newOpportunities){
 			Opportunity newOpportunity=opportunity;
 			Opportunity oldOpportunity=oldOpportunitiesByIds.get(newOpportunity.Id);

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -50,10 +50,10 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 	}
 
 	public static Boolean doesOpportunityOwnerCountryMatchNavisionCustomerCountry(Opportunity opportunity){
-		Account parenAccount=parentAccountsByIds.get(opportunity.AccountId);
+		Account parentAccount=parentAccountsByIds.get(opportunity.AccountId);
 		return
-				opportunity.Owner.Country=='Norway' && parenAccount.Navision_Customer_NO__c ||
-				opportunity.Owner.Country=='Sweden' && parenAccount.Navision_Customer_SE__c ||
-				opportunity.Owner.Country=='Denmark' && parenAccount.Navision_Customer_DK__c;
+				opportunity.Owner.Country=='Norway' && parentAccount.Navision_Customer_NO__c ||
+				opportunity.Owner.Country=='Sweden' && parentAccount.Navision_Customer_SE__c ||
+				opportunity.Owner.Country=='Denmark' && parentAccount.Navision_Customer_DK__c;
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -1,8 +1,12 @@
 public with sharing class UpsertContractOnAwardedOpportunities implements TriggerAction.BeforeUpdate{
-
+	@TestVisible
+	private static Map<Id, Account> parentAccountsByIds;
 	public void beforeUpdate(List<Opportunity> newOpportunities, List<Opportunity> oldOpportunities) {
 		Logger.debug('UpsertContractOnAwardedOpportunities - Before Update');
+		Logger.suspendSaving();
 		Map<Id, Opportunity> oldOpportunitiesByIds = new Map<Id, Opportunity>(oldOpportunities);
+		parentAccountsByIds = getAccountByIdsFromChildOpportunities(newOpportunities);
+
 		Formula.recalculateFormulas(newOpportunities); // To ensure that Navision_Account_in_Owners_Country__c is up to date
 		for (Opportunity opportunity:newOpportunities){
 			Opportunity newOpportunity=opportunity;
@@ -15,18 +19,19 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 			if(
 				newOpportunity.New_Or_Renewal__c == 'New' &&
 				String.isBlank(newOpportunity.ContractServiceNowUrl__c) &&
-				newOpportunity.Navision_Account_in_Owners_Country__c
+				doesOpportunityOwnerCountryMatchNavisionCustomerCountry(newOpportunity)
 			){
 				DML.enqueueJob(new ServiceNowUploadContractsQueueable(newOpportunity));
 				Logger.info('Contract is created in ServiceNow for this Opportunity', newOpportunity).addTag('Opportunity trigger handler service');
+				Logger.resumeSaving();
 			} else {
 				Logger.info('Contract is not created is ServiceNow for this Opportunity', newOpportunity).addTag('Opportunity trigger handler service');
 				Logger.info('New or renewal: ' + newOpportunity.New_Or_Renewal__c).addTag('Opportunity trigger handler service');
 				Logger.info('Service Now contract url: ' + newOpportunity.ContractServiceNowUrl__c).addTag('Opportunity trigger handler service');
-				if (!newOpportunity.Navision_Account_in_Owners_Country__c) {
+				if (!doesOpportunityOwnerCountryMatchNavisionCustomerCountry(newOpportunity)) {
 					Logger.error('Opportunity Owner Country: "'+opportunity.Owner_Country__c+'" does not match the Account\'s Country in Navision').addTag('Opportunity trigger handler service');
 				}
-
+				Logger.resumeSaving();
 			}
 		}
 		Logger.saveLog();
@@ -34,5 +39,21 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 
 	public static Boolean hasOpportunityStageChangedToAwarded(Opportunity oldOpportunity, Opportunity newOpportunity){
 		return (newOpportunity.StageName == Utils.AWARDED && newOpportunity.StageName != oldOpportunity.StageName);
+	}
+
+	public static Map<Id, Account> getAccountByIdsFromChildOpportunities(List<Opportunity> newOpportunities){
+		Set<Id> accountIds = new Set<Id>();
+		for (Opportunity opportunity:newOpportunities){
+			accountIds.add(opportunity.AccountId);
+		}
+		return new Map<Id, Account>([SELECT Navision_Customer_NO__c, Navision_Customer_DK__c, Navision_Customer_SE__c FROM Account WHERE Id IN: accountIds]);
+	}
+
+	public static Boolean doesOpportunityOwnerCountryMatchNavisionCustomerCountry(Opportunity opportunity){
+		Account parenAccount=parentAccountsByIds.get(opportunity.AccountId);
+		return
+				opportunity.Owner.Country=='Norway' && parenAccount.Navision_Customer_NO__c ||
+				opportunity.Owner.Country=='Sweden' && parenAccount.Navision_Customer_SE__c ||
+				opportunity.Owner.Country=='Denmark' && parenAccount.Navision_Customer_DK__c;
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -17,7 +17,7 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 				String.isBlank(newOpportunity.ContractServiceNowUrl__c) &&
 				newOpportunity.Navision_Account_in_Owners_Country__c
 			){
-				System.enqueueJob(new ServiceNowUploadContractsQueueable(newOpportunity));
+				DML.enqueueJob(new ServiceNowUploadContractsQueueable(newOpportunity));
 				Logger.info('Contract is created in ServiceNow for this Opportunity', newOpportunity).addTag('Opportunity trigger handler service');
 			} else {
 				Logger.info('Contract is not created is ServiceNow for this Opportunity', newOpportunity).addTag('Opportunity trigger handler service');

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -34,6 +34,7 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 			}
 		}
 		Logger.saveLog();
+		Logger.resumeSaving();
 	}
 
 	public static Boolean hasOpportunityStageChangedToAwarded(Opportunity oldOpportunity, Opportunity newOpportunity){

--- a/force-app/classes/processes/tests/UpsertContractOnAwardedOpportunitiesTest.cls
+++ b/force-app/classes/processes/tests/UpsertContractOnAwardedOpportunitiesTest.cls
@@ -1,47 +1,43 @@
 @IsTest
 public with sharing class UpsertContractOnAwardedOpportunitiesTest {
+    @IsTest
+    static void testOpportunityStageHasNotChangedToAwarded() {
+        Opportunity oldOpportunity = TestDataFactory.createOpportunities(1, false, true)[0];
+        oldOpportunity.StageName = Utils.PLANNING_0;
+        Opportunity newOpportunity = oldOpportunity.clone(true);
+        Assert.isFalse(UpsertContractOnAwardedOpportunities.hasOpportunityStageChangedToAwarded(oldOpportunity, newOpportunity));
+    }
 
-	@IsTest
-	static void testOpportunityStageHasNotChangedToAwarded(){
-		Opportunity oldOpportunity = TestDataFactory.createOpportunities(1,false,true)[0];
-		oldOpportunity.StageName = Utils.PLANNING_0;
-		Opportunity newOpportunity = oldOpportunity.clone(true);
-		Assert.isFalse(UpsertContractOnAwardedOpportunities.hasOpportunityStageChangedToAwarded(oldOpportunity, newOpportunity));
-	}
+    @IsTest
+    static void testOpportunityStageHasChangedToAwarded() {
+        Opportunity oldOpportunity = TestDataFactory.createOpportunities(1, false, true)[0];
+        oldOpportunity.StageName = Utils.PLANNING_0;
+        Opportunity newOpportunity = oldOpportunity.clone(true);
+        newOpportunity.StageName = Utils.AWARDED;
+        Assert.isTrue(UpsertContractOnAwardedOpportunities.hasOpportunityStageChangedToAwarded(oldOpportunity, newOpportunity));
+    }
 
-	@IsTest
-	static void testOpportunityStageHasChangedToAwarded(){
-		Opportunity oldOpportunity = TestDataFactory.createOpportunities(1,false,true)[0];
-		oldOpportunity.StageName = Utils.PLANNING_0;
-		Opportunity newOpportunity = oldOpportunity.clone(true);
-		newOpportunity.StageName=Utils.AWARDED;
-		Assert.isTrue(UpsertContractOnAwardedOpportunities.hasOpportunityStageChangedToAwarded(oldOpportunity, newOpportunity));
-	}
+    @IsTest
+    static void shouldEnqueueServiceNowUploadContractsQueueable() {
+        DML.isMockDML = true;
+        List<Opportunity> oldOpportunities = TestDataFactory.createOpportunities(2, false, true);
+        oldOpportunities[0].Account.Navision_Customer_NO__c = true;
+        oldOpportunities[1].Account.Navision_Customer_SE__c = true;
+        User u = new User(Id = UserInfo.getUserId(), Country = 'Sweden');
+        oldOpportunities[0].Owner = u;
+        oldOpportunities[1].Owner = u;
+        oldOpportunities[0].New_or_Renewal__c = 'New';
+        oldOpportunities[1].New_or_Renewal__c = 'New';
+        List<Opportunity> newOpportunities = oldOpportunities.deepClone(true);
+        newOpportunities[0].StageName = Utils.AWARDED;
+        newOpportunities[1].StageName = Utils.AWARDED;
+        UpsertContractOnAwardedOpportunities testUpsertContractOnAwardedOpportunities = new UpsertContractOnAwardedOpportunities();
 
-	@IsTest
-	static void mockedOpportunityShouldEnqueueServiceNowUploadContractsQueueableWhenNewlyAwardedOpportunityOwnerMatchesNavisionCustomerCountry(){
-		DML.isMockDML=true;
-		List<Opportunity> oldOpportunities = TestDataFactory.createOpportunities(2,false,true);
-		oldOpportunities[0].Account.Navision_Customer_NO__c=true;
-		oldOpportunities[1].Account.Navision_Customer_SE__c=true;
-		User u = new User(
-				Id=UserInfo.getUserId(),
-				Country='Sweden'
-		);
-		oldOpportunities[0].Owner=u;
-		oldOpportunities[1].Owner=u;
-		oldOpportunities[0].New_or_Renewal__c='New';
-		oldOpportunities[1].New_or_Renewal__c='New';
-		List<Opportunity> newOpportunities = oldOpportunities.deepClone(true);
-		newOpportunities[0].StageName=Utils.AWARDED;
-		newOpportunities[1].StageName=Utils.AWARDED;
-		UpsertContractOnAwardedOpportunities testUpsertContractOnAwardedOpportunities = new UpsertContractOnAwardedOpportunities();
+        Test.startTest();
+        testUpsertContractOnAwardedOpportunities.beforeUpdate(newOpportunities, oldOpportunities);
+        Test.stopTest();
 
-		Test.startTest();
-		testUpsertContractOnAwardedOpportunities.beforeUpdate(newOpportunities, oldOpportunities);
-		Test.stopTest();
-
-		Assert.isFalse(DML.enqueuedJobs.isEmpty(),'1 Queueable job should be queued');
-		Assert.isInstanceOfType(DML.enqueuedJobs[0],ServiceNowUploadContractsQueueable.class, 'ServiceNowUploadContractsQueueable should be queued');
-	}
+        Assert.isFalse(DML.enqueuedJobs.isEmpty(), '1 Queueable job should be queued');
+        Assert.isInstanceOfType(DML.enqueuedJobs[0], ServiceNowUploadContractsQueueable.class, 'ServiceNowUploadContractsQueueable should be queued');
+    }
 }

--- a/force-app/classes/processes/tests/UpsertContractOnAwardedOpportunitiesTest.cls
+++ b/force-app/classes/processes/tests/UpsertContractOnAwardedOpportunitiesTest.cls
@@ -19,32 +19,29 @@ public with sharing class UpsertContractOnAwardedOpportunitiesTest {
 	}
 
 	@IsTest
-	static void testOpportunityOwnerCountryMatchesNavisionCustomerCountry(){
-		Opportunity oldOpportunity = TestDataFactory.createOpportunities(1,false,true)[0];
-		oldOpportunity.Navision_Customer_NO__c=true;
-		User u = new User(
-				Id=UserInfo.getUserId(),
-				Country='Norway'
-		);
-		oldOpportunity.Owner=u;
-		Opportunity newOpportunity = oldOpportunity.clone(true);
-		Formula.recalculateFormulas(new List<Opportunity>{newOpportunity});
-		Assert.isTrue(newOpportunity.Navision_Account_in_Owners_Country__c);
-		Assert.isTrue(UpsertContractOnAwardedOpportunities.doesOpportunityOwnerCountryMatchNavisionCustomerCountry(oldOpportunity,newOpportunity));
-	}
-
-	@IsTest
-	static void testOpportunityOwnerCountryDoesNotMatchNavisionCustomerCountry(){
-		Opportunity oldOpportunity = TestDataFactory.createOpportunities(1,false,true)[0];
-		oldOpportunity.Navision_Customer_NO__c=true;
+	static void mockedOpportunityShouldEnqueueServiceNowUploadContractsQueueableWhenNewlyAwardedOpportunityOwnerMatchesNavisionCustomerCountry(){
+		DML.isMockDML=true;
+		List<Opportunity> oldOpportunities = TestDataFactory.createOpportunities(2,false,true);
+		oldOpportunities[0].Account.Navision_Customer_NO__c=true;
+		oldOpportunities[1].Account.Navision_Customer_SE__c=true;
 		User u = new User(
 				Id=UserInfo.getUserId(),
 				Country='Sweden'
 		);
-		oldOpportunity.Owner=u;
-		Opportunity newOpportunity = oldOpportunity.clone(true);
-		Formula.recalculateFormulas(new List<Opportunity>{newOpportunity});
-		Assert.isTrue(newOpportunity.Navision_Account_in_Owners_Country__c);
-		Assert.isTrue(UpsertContractOnAwardedOpportunities.doesOpportunityOwnerCountryMatchNavisionCustomerCountry(oldOpportunity,newOpportunity));
+		oldOpportunities[0].Owner=u;
+		oldOpportunities[1].Owner=u;
+		oldOpportunities[0].New_or_Renewal__c='New';
+		oldOpportunities[1].New_or_Renewal__c='New';
+		List<Opportunity> newOpportunities = oldOpportunities.deepClone(true);
+		newOpportunities[0].StageName=Utils.AWARDED;
+		newOpportunities[1].StageName=Utils.AWARDED;
+		UpsertContractOnAwardedOpportunities testUpsertContractOnAwardedOpportunities = new UpsertContractOnAwardedOpportunities();
+
+		Test.startTest();
+		testUpsertContractOnAwardedOpportunities.beforeUpdate(newOpportunities, oldOpportunities);
+		Test.stopTest();
+
+		Assert.isFalse(DML.enqueuedJobs.isEmpty(),'1 Queueable job should be queued');
+		Assert.isInstanceOfType(DML.enqueuedJobs[0],ServiceNowUploadContractsQueueable.class, 'ServiceNowUploadContractsQueueable should be queued');
 	}
 }

--- a/force-app/classes/processes/tests/UpsertContractOnAwardedOpportunitiesTest.cls
+++ b/force-app/classes/processes/tests/UpsertContractOnAwardedOpportunitiesTest.cls
@@ -18,26 +18,44 @@ public with sharing class UpsertContractOnAwardedOpportunitiesTest {
     }
 
     @IsTest
+    static void testOpportunityOwnerCountryMatchesNavisionCustomerCountry(){
+        List<Opportunity> opportunities = TestDataFactory.createOpportunities(2,false,true);
+        UpsertContractOnAwardedOpportunities.parentAccountsByIds=new Map<Id, Account>{
+                opportunities[0].AccountId => new Account(Navision_Customer_SE__c=true)
+        };
+        opportunities[0].Owner= new User(Id = UserInfo.getUserId(), Country = 'Sweden');
+        opportunities[1].Owner=new User(Id = UserInfo.getUserId(), Country = 'Norway');
+
+        Assert.isTrue(UpsertContractOnAwardedOpportunities.doesOpportunityOwnerCountryMatchNavisionCustomerCountry(opportunities[0]),'Swedish Opportunity should match Swedish Account');
+        Assert.isFalse(UpsertContractOnAwardedOpportunities.doesOpportunityOwnerCountryMatchNavisionCustomerCountry(opportunities[1]),'Norwegian Opportunity should not match Swedish Account');
+    }
+
+    //TODO: Create 1 Account for each Opportunity if mocking does not work
+    @IsTest
     static void shouldEnqueueServiceNowUploadContractsQueueable() {
         DML.isMockDML = true;
+        List<Account> accounts = TestDataFactory.createAccounts(2, false,false);
+        accounts[0].Navision_Customer_NO__c=true;
+        accounts[1].Navision_Customer_SE__c=true;
+        insert accounts;
         List<Opportunity> oldOpportunities = TestDataFactory.createOpportunities(2, false, true);
-        oldOpportunities[0].Account.Navision_Customer_NO__c = true;
-        oldOpportunities[1].Account.Navision_Customer_SE__c = true;
+        oldOpportunities[0].AccountId = accounts[0].Id;
+        oldOpportunities[1].AccountId = accounts[1].Id;
         User u = new User(Id = UserInfo.getUserId(), Country = 'Sweden');
+
         oldOpportunities[0].Owner = u;
         oldOpportunities[1].Owner = u;
         oldOpportunities[0].New_or_Renewal__c = 'New';
         oldOpportunities[1].New_or_Renewal__c = 'New';
+
         List<Opportunity> newOpportunities = oldOpportunities.deepClone(true);
         newOpportunities[0].StageName = Utils.AWARDED;
         newOpportunities[1].StageName = Utils.AWARDED;
         UpsertContractOnAwardedOpportunities testUpsertContractOnAwardedOpportunities = new UpsertContractOnAwardedOpportunities();
 
-        Test.startTest();
         testUpsertContractOnAwardedOpportunities.beforeUpdate(newOpportunities, oldOpportunities);
-        Test.stopTest();
 
-        Assert.isFalse(DML.enqueuedJobs.isEmpty(), '1 Queueable job should be queued');
+        Assert.areEqual(1,DML.enqueuedJobs.size(), '1 Queueable job should be queued');
         Assert.isInstanceOfType(DML.enqueuedJobs[0], ServiceNowUploadContractsQueueable.class, 'ServiceNowUploadContractsQueueable should be queued');
     }
 }

--- a/force-app/classes/utils/DML.cls
+++ b/force-app/classes/utils/DML.cls
@@ -1,0 +1,11 @@
+public class DML {
+	@TestVisible
+	private static Boolean isMockDML = false;
+	@TestVisible
+	private static List<Object> enqueuedJobs = new List<Object>();
+
+	public static void enqueueJob(Object queueable){
+		if (!isMockDML) { System.enqueueJob(queueable); }
+		enqueuedJobs.add(queueable);
+	}
+}

--- a/force-app/classes/utils/DML.cls-meta.xml
+++ b/force-app/classes/utils/DML.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>63.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/force-app/lwc/fileUploadMulti/fileUploadMulti.js
+++ b/force-app/lwc/fileUploadMulti/fileUploadMulti.js
@@ -3,16 +3,13 @@ import {getFieldValue, getRecord, getRecordNotifyChange, notifyRecordUpdateAvail
 import CONTRACT_CATEGORY from "@salesforce/schema/Opportunity.Contract_Category__c";
 import CONTRACT_SERVICE_NOW_URL from '@salesforce/schema/Opportunity.ContractServiceNowUrl__c';
 import IS_CONTRACT_UPLOADED from '@salesforce/schema/Opportunity.IsContractUploaded__c';
-import NAVISION_SE from '@salesforce/schema/Opportunity.Navision_Customer_SE__c';
-import NAVISION_NO from '@salesforce/schema/Opportunity.Navision_Customer_NO__c';
-import NAVISION_DK from '@salesforce/schema/Opportunity.Navision_Customer_DK__c';
 import NAVISION_ACCOUNT from '@salesforce/schema/Opportunity.Navision_Account_in_Owners_Country__c';
 import OPPORTUNITY_OWNER_COUNTRY from '@salesforce/schema/Opportunity.Owner_Country__c';
 import STAGE_NAME from '@salesforce/schema/Opportunity.StageName';
 import {onError, subscribe, unsubscribe} from "lightning/empApi";
 import { RefreshEvent } from 'lightning/refresh';
 import {refreshApex} from "@salesforce/apex";
-const FIELDS = [IS_CONTRACT_UPLOADED,CONTRACT_SERVICE_NOW_URL,CONTRACT_CATEGORY,STAGE_NAME,NAVISION_SE,NAVISION_DK,NAVISION_NO,OPPORTUNITY_OWNER_COUNTRY,NAVISION_ACCOUNT];
+const FIELDS = [IS_CONTRACT_UPLOADED,CONTRACT_SERVICE_NOW_URL,CONTRACT_CATEGORY,STAGE_NAME,'Opportunity.Account.Navision_Customer_SE__c','Opportunity.Account.Navision_Customer_NO__c','Opportunity.Account.Navision_Customer_DK__c',OPPORTUNITY_OWNER_COUNTRY,NAVISION_ACCOUNT];
 
 export default class fileUploadMulti extends LightningElement {
     fields = FIELDS;
@@ -41,10 +38,10 @@ export default class fileUploadMulti extends LightningElement {
         self.refreshMyData();
         if(this.opportunity.data){
             this.showConditionalSection = this.opportunity.data.fields.StageName.value === '5 - Awarded' && (this.opportunity.data.fields.ContractServiceNowUrl__c.value === null || this.opportunity.data.fields.ContractServiceNowUrl__c.value === undefined || this.opportunity.data.fields.ContractServiceNowUrl__c.value === '');
-            this.navisionCheck = ((this.opportunity.data.fields.Navision_Customer_DK__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Denmark') || (this.opportunity.data.fields.Navision_Customer_SE__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Sweden') || (this.opportunity.data.fields.Navision_Customer_NO__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Norway')) || this.opportunity.data.fields.Navision_Account_in_Owners_Country__c.value === true;
-            console.log(this.opportunity.data.fields.Navision_Customer_NO__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Norway');
-            console.log(this.opportunity.data.fields.Navision_Customer_SE__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Sweden');
-            console.log(this.opportunity.data.fields.Navision_Customer_DK__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Denmark');
+            this.navisionCheck = ((this.opportunity.data.fields.Account.Navision_Customer_DK__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Denmark') || (this.opportunity.data.fields.Account.Navision_Customer_SE__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Sweden') || (this.opportunity.data.fields.Account.Navision_Customer_NO__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Norway')) || this.opportunity.data.fields.Navision_Account_in_Owners_Country__c.value === true;
+            console.log(this.opportunity.data.fields.Account.Navision_Customer_NO__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Norway');
+            console.log(this.opportunity.data.fields.Account.Navision_Customer_SE__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Sweden');
+            console.log(this.opportunity.data.fields.Account.Navision_Customer_DK__c.value === true && this.opportunity.data.fields.Owner_Country__c === 'Denmark');
             console.log(this.opportunity.data.fields.Navision_Account_in_Owners_Country__c.value === true);
         }
         refreshApex(this.opportunity).then(() => {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,7 +3,7 @@
         {
             "path": "force-app",
             "package": "document-transfer",
-            "versionNumber": "0.2.0.NEXT",
+            "versionNumber": "0.3.0.NEXT",
             "versionDescription": "Handles document transfer logic, logging, and integration support.",
             "default": true,
             "seedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -27,7 +27,7 @@
                 },
                 {
                     "package": "platform-base",
-                    "versionNumber": "0.1.0.LATEST"
+                    "versionNumber": "1.0.0.LATEST"
                 }
             ]
         }


### PR DESCRIPTION
Since formula fields might give wrong results in Before Triggers, a new method in the Trigger action is created evaluating if Opportunity Owner Country matches the Country table in Navision that the Account resides in