### PR TITLE
[CIS-111] account trigger upsert contract

### DIFF
--- a/force-app/classes/domains/AwardedOpportunities.cls
+++ b/force-app/classes/domains/AwardedOpportunities.cls
@@ -44,12 +44,10 @@ public inherited sharing class AwardedOpportunities extends Opportunities{
 			){
 				opportunitiesWithNoContractInServiceNow.add(opportunity);
 				Logger.info('Contract is created in ServiceNow for this Opportunity', opportunity).addTag('Opportunity trigger handler service');
-				Logger.resumeSaving();
 			} else {
 				Logger.info('Contract is not created is ServiceNow for this Opportunity', opportunity).addTag('Opportunity trigger handler service');
 				Logger.info('New or renewal: ' + opportunity.New_Or_Renewal__c).addTag('Opportunity trigger handler service');
 				Logger.info('Service Now contract url: ' + opportunity.ContractServiceNowUrl__c).addTag('Opportunity trigger handler service');
-				Logger.resumeSaving();
 			}
 		}
 		if (!this.isEmpty()) {

--- a/force-app/classes/domains/AwardedOpportunities.cls
+++ b/force-app/classes/domains/AwardedOpportunities.cls
@@ -35,7 +35,7 @@ public inherited sharing class AwardedOpportunities extends Opportunities{
 		return this;
 	}
 
-	public AwardedOpportunities getNewOpportunitiesWithNoContractInServiceNow(){
+	public AwardedOpportunities filterNewOpportunitiesWithoutContracts(){
 		List<Opportunity> opportunitiesWithNoContractInServiceNow = new List<Opportunity>();
 		for (Opportunity opportunity:this.opportunities){
 			if(

--- a/force-app/classes/domains/AwardedOpportunities.cls
+++ b/force-app/classes/domains/AwardedOpportunities.cls
@@ -18,9 +18,12 @@ public inherited sharing class AwardedOpportunities extends Opportunities{
 				awardedOpportunities.add(newOpportunity);
 			}
 		}
-		this.opportunities =awardedOpportunities;
+		this.opportunities=awardedOpportunities;
 	}
 
+	/**
+	 * @description: Remove Opportunities where Owner Country does not match the Country that the Parent Account is registerd in Navision
+	 */
 	public AwardedOpportunities filterByMatchingOwnerCountry(){
 		List<Opportunity> opportunitiesWhereOwnerCountryMatchesNavisionCountry = new List<Opportunity>();
 		for (Opportunity opportunity:this.opportunities){
@@ -32,6 +35,38 @@ public inherited sharing class AwardedOpportunities extends Opportunities{
 		}
 		this.opportunities =opportunitiesWhereOwnerCountryMatchesNavisionCountry;
 		return this;
+	}
+
+	public AwardedOpportunities getNewOpportunitiesWithNoContractInServiceNow(){
+		List<Opportunity> opportunitiesWithNoContractInServiceNow = new List<Opportunity>();
+		for (Opportunity opportunity:this.opportunities){
+			if(
+				opportunity.New_Or_Renewal__c == 'New' &&
+				String.isBlank(opportunity.ContractServiceNowUrl__c)
+			){
+				opportunitiesWithNoContractInServiceNow.add(opportunity);
+				Logger.info('Contract is created in ServiceNow for this Opportunity', opportunity).addTag('Opportunity trigger handler service');
+				Logger.resumeSaving();
+			} else {
+				Logger.info('Contract is not created is ServiceNow for this Opportunity', opportunity).addTag('Opportunity trigger handler service');
+				Logger.info('New or renewal: ' + opportunity.New_Or_Renewal__c).addTag('Opportunity trigger handler service');
+				Logger.info('Service Now contract url: ' + opportunity.ContractServiceNowUrl__c).addTag('Opportunity trigger handler service');
+				Logger.resumeSaving();
+			}
+		}
+		if (!this.isEmpty()) {
+			Logger.saveLog();
+		}
+
+		this.opportunities=opportunitiesWithNoContractInServiceNow;
+		return this;
+	}
+
+	public void upsertContractToServiceNow(){
+		//TODO: Bulkify - CIS-105
+		for (Opportunity opportunity:this.opportunities){
+			DML.enqueueJob(new ServiceNowUploadContractsQueueable(opportunity));
+		}
 	}
 
 	public Boolean doesOpportunityOwnerCountryMatchNavisionCustomerCountry(Account parentAccount, User opportunityOwner){

--- a/force-app/classes/domains/AwardedOpportunities.cls
+++ b/force-app/classes/domains/AwardedOpportunities.cls
@@ -1,24 +1,22 @@
 public inherited sharing class AwardedOpportunities extends Opportunities{
 	public AwardedOpportunities(List<Opportunity> opportunities) {
-		List<Opportunity> awardedOpportunities = new List<Opportunity>();
+		this.opportunities = new List<Opportunity>();
 		for (Opportunity opportunity : opportunities) {
 			if (opportunity.StageName == AWARDED) {
-				awardedOpportunities.add(opportunity);
+				this.opportunities.add(opportunity);
 			}
 		}
-		this.opportunities =awardedOpportunities;
 	}
 
 	public AwardedOpportunities(List<Opportunity> newOpportunities, List<Opportunity> oldOpportunities) {
-		List<Opportunity> awardedOpportunities = new List<Opportunity>();
+		this.opportunities = new List<Opportunity>();
 		Map<Id, Opportunity> oldOpportunitiesByIds = new Map<Id, Opportunity>(oldOpportunities);
 		for (Opportunity newOpportunity : newOpportunities) {
 			Opportunity oldOpportunity = oldOpportunitiesByIds.get(newOpportunity.Id);
 			if (newOpportunity.StageName == AWARDED && newOpportunity.StageName!=oldOpportunity.StageName) {
-				awardedOpportunities.add(newOpportunity);
+				this.opportunities.add(newOpportunity);
 			}
 		}
-		this.opportunities=awardedOpportunities;
 	}
 
 	/**

--- a/force-app/classes/domains/AwardedOpportunities.cls
+++ b/force-app/classes/domains/AwardedOpportunities.cls
@@ -25,7 +25,9 @@ public inherited sharing class AwardedOpportunities extends Opportunities{
 	public AwardedOpportunities filterByMatchingOwnerCountry(){
 		List<Opportunity> opportunitiesWhereOwnerCountryMatchesNavisionCountry = new List<Opportunity>();
 		for (Opportunity opportunity:this.opportunities){
-			if (doesOpportunityOwnerCountryMatchNavisionCustomerCountry(parentAccountsByIds.get(opportunity.AccountId), opportunityOwnersByIds.get(opportunity.OwnerId))) {
+			Account parentAccount = parentAccountsByIds.get(opportunity.AccountId);
+			User opportunityOwner = opportunityOwnersByIds.get(opportunity.OwnerId);
+			if (doesOpportunityOwnerCountryMatchNavisionCustomerCountry(parentAccount, opportunityOwner)) {
 				opportunitiesWhereOwnerCountryMatchesNavisionCountry.add(opportunity);
 			} else{
 				Logger.error('Opportunity Owner Country: "'+opportunity.Owner_Country__c+'" does not match the Account\'s Country in Navision', opportunity);

--- a/force-app/classes/domains/NavisionAccounts.cls
+++ b/force-app/classes/domains/NavisionAccounts.cls
@@ -1,0 +1,44 @@
+public with sharing class NavisionAccounts {
+
+	private List<Account> accounts;
+
+	public NavisionAccounts(List<Account> accounts) {
+		this.accounts = new List<Account>();
+		for (Account account : accounts) {
+			if (
+					account.Navision_Customer_NO__c == true ||
+					account.Navision_Customer_SE__c == true ||
+					account.Navision_Customer_DK__c == true
+			) {
+				this.accounts.add(account);
+			}
+		}
+	}
+
+	public List<Account> getAccounts() {
+		return this.accounts;
+	}
+
+	public NavisionAccounts filterAccountsWithNavisionCountryPositiveChange(List<Account> oldAccounts) {
+		Map<Id, Account> oldAccountsById = new Map<Id, Account>(oldAccounts);
+		List<Account> filteredAccounts = new List<Account>();
+
+		for (Account newAccount : accounts) {
+			Account oldAccount = oldAccountsById.get(newAccount.Id);
+			if (oldAccount == null) continue;
+
+			if (
+					(newAccount.Navision_Customer_NO__c == true && oldAccount.Navision_Customer_NO__c != true) ||
+					(newAccount.Navision_Customer_SE__c == true && oldAccount.Navision_Customer_SE__c != true) ||
+					(newAccount.Navision_Customer_DK__c == true && oldAccount.Navision_Customer_DK__c != true)
+			) {
+				filteredAccounts.add(newAccount);
+			}
+		}
+
+		return new NavisionAccounts(filteredAccounts);
+	}
+	public Set<Id> getAccountIds() {
+		return new Map<Id, Account>(this.accounts).keySet();
+	}
+}

--- a/force-app/classes/domains/NavisionAccounts.cls-meta.xml
+++ b/force-app/classes/domains/NavisionAccounts.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>63.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/force-app/classes/domains/Opportunities.cls
+++ b/force-app/classes/domains/Opportunities.cls
@@ -16,7 +16,7 @@ public inherited sharing abstract class Opportunities {
 			}
 			return parentAccountsByIds;
 		}
-		private set;
+		set;
 	}
 
 	public Map<Id, User> opportunityOwnersByIds {

--- a/force-app/classes/domains/Opportunities.cls
+++ b/force-app/classes/domains/Opportunities.cls
@@ -33,6 +33,10 @@ public inherited sharing abstract class Opportunities {
 		return this.opportunities.isEmpty();
 	}
 
+	public Integer size(){
+		return this.opportunities.size();
+	}
+
 	public Map<Id, Account> getParentAccountByIds(){
 		Set<Id> accountIds = new Set<Id>();
 		for (Opportunity opportunity:this.opportunities){

--- a/force-app/classes/domains/tests/AwardedOpportunitiesTest.cls
+++ b/force-app/classes/domains/tests/AwardedOpportunitiesTest.cls
@@ -8,7 +8,7 @@ public with sharing class AwardedOpportunitiesTest {
 			opportunity.StageName = Utils.PLANNING_0; //Must use Utils instead on Opportunities to avoid getting "Variable does not exist: AWARDED" on Deployment (known issue for Abstract classes)
 		}
 		AwardedOpportunities newlyAwardedOpportunities = new AwardedOpportunities(opportunities);
-		Assert.isTrue(newlyAwardedOpportunities.getRecords().isEmpty());
+		Assert.isTrue(newlyAwardedOpportunities.isEmpty());
 	}
 
 	@IsTest
@@ -19,7 +19,7 @@ public with sharing class AwardedOpportunitiesTest {
 		AwardedOpportunities newlyAwardedOpportunities = new AwardedOpportunities(opportunities);
 		Assert.areEqual(
 				2,
-				newlyAwardedOpportunities.getRecords().size(),
+				newlyAwardedOpportunities.size(),
 				'2 Opportunities should remain after filtering out awarded Opportunities');
 	}
 
@@ -35,7 +35,7 @@ public with sharing class AwardedOpportunitiesTest {
 		AwardedOpportunities newlyAwardedOpportunities = new AwardedOpportunities(newOpportunities, oldOpportunities);
 		Assert.areEqual(
 				2,
-				newlyAwardedOpportunities.getRecords().size(),
+				newlyAwardedOpportunities.size(),
 				'2 Opportunities should remain after filtering out newly awarded Opportunities'
 		);
 	}
@@ -74,7 +74,21 @@ public with sharing class AwardedOpportunitiesTest {
 		AwardedOpportunities awardedOpportunities = new AwardedOpportunities(opportunities);
 		System.debug(awardedOpportunities.getRecords());
 		awardedOpportunities.filterByMatchingOwnerCountry();
-		Assert.areEqual(1, awardedOpportunities.getRecords().size(), '1 Awarded Opportunity Owner should match Navision Country');
+		Assert.areEqual(1, awardedOpportunities.size(), '1 Awarded Opportunity Owner should match Navision Country');
 		Assert.areEqual(opportunities[1].Id, awardedOpportunities.getRecords()[0].Id, 'Only 1 Awarded Opportunity Owner Matches Navision Country');
+	}
+
+	@IsTest
+	static void shouldReturn1NewOpportunityWithNoContractInServiceNow(){
+		List<Opportunity> opportunities = TestDataFactory.createOpportunities(2,false,true);
+		opportunities[0].New_or_Renewal__c='New';
+		opportunities[1].New_or_Renewal__c='New';
+		opportunities[0].ContractServiceNowUrl__c='URL';
+		opportunities[0].StageName=Utils.AWARDED;
+		opportunities[1].StageName=Utils.AWARDED;
+		AwardedOpportunities awardedOpportunities = new AwardedOpportunities(opportunities);
+		awardedOpportunities.getNewOpportunitiesWithNoContractInServiceNow();
+		Assert.areEqual(1, awardedOpportunities.size(), 'Only 1 New Opportunity should remain');
+		Assert.areEqual(opportunities[1].Id, awardedOpportunities.getRecords()[0].Id,'Only the Opportunity without Contract ServiceNow URL should remain');
 	}
 }

--- a/force-app/classes/domains/tests/AwardedOpportunitiesTest.cls
+++ b/force-app/classes/domains/tests/AwardedOpportunitiesTest.cls
@@ -87,7 +87,7 @@ public with sharing class AwardedOpportunitiesTest {
 		opportunities[0].StageName=Utils.AWARDED;
 		opportunities[1].StageName=Utils.AWARDED;
 		AwardedOpportunities awardedOpportunities = new AwardedOpportunities(opportunities);
-		awardedOpportunities.getNewOpportunitiesWithNoContractInServiceNow();
+		awardedOpportunities.filterNewOpportunitiesWithoutContracts();
 		Assert.areEqual(1, awardedOpportunities.size(), 'Only 1 New Opportunity should remain');
 		Assert.areEqual(opportunities[1].Id, awardedOpportunities.getRecords()[0].Id,'Only the Opportunity without Contract ServiceNow URL should remain');
 	}

--- a/force-app/classes/domains/tests/TestNavisionAccounts.cls
+++ b/force-app/classes/domains/tests/TestNavisionAccounts.cls
@@ -1,0 +1,17 @@
+@IsTest
+public with sharing class TestNavisionAccounts {
+
+	@IsTest
+	static void shouldReturnAccountswithPositiveNavisionChange(){
+		List<Account> oldAccounts = TestDataFactory.createAccounts(4, false, true);
+		List<Account> newAccounts = oldAccounts.deepClone(true);
+		newAccounts[0].Navision_Customer_NO__c=true;
+
+		Assert.areEqual(1, new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts).getAccounts().size(), 'One Account should remain after filtering');
+		Assert.areEqual(newAccounts[0].Id,new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts).getAccounts()[0].Id, 'Only the first Account should remain after filtering');
+
+		oldAccounts[1].Navision_Customer_SE__c=true;
+		Assert.areEqual(1,new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts).getAccounts().size(), 'Only Account with Navision Change from False to True should remain after filtering');
+		Assert.areEqual(newAccounts[0].Id,new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts).getAccounts()[0].Id, 'Only the first Account should remain after filtering');
+	}
+}

--- a/force-app/classes/domains/tests/TestNavisionAccounts.cls-meta.xml
+++ b/force-app/classes/domains/tests/TestNavisionAccounts.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>63.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -7,7 +7,7 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 		newlyAwardedOpportunities.filterByMatchingOwnerCountry();
 		newlyAwardedOpportunities.filterNewOpportunitiesWithoutContracts();
 		if (!newlyAwardedOpportunities.isEmpty()) {
-			new AwardedOpportunities(newlyAwardedOpportunities.getRecords()).upsertContractToServiceNow();
+			newlyAwardedOpportunities.upsertContractToServiceNow();
 		}
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -2,32 +2,12 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 
 	public void beforeUpdate(List<Opportunity> newOpportunities, List<Opportunity> oldOpportunities) {
 		Logger.debug('UpsertContractOnAwardedOpportunities - Before Update');
-		Logger.suspendSaving();
 
 		AwardedOpportunities newlyAwardedOpportunities = new AwardedOpportunities(newOpportunities, oldOpportunities);
 		newlyAwardedOpportunities.filterByMatchingOwnerCountry();
+		newlyAwardedOpportunities.getNewOpportunitiesWithNoContractInServiceNow();
 		if (!newlyAwardedOpportunities.isEmpty()) {
-			upsertContractOnNewAwardedOpportunities(newlyAwardedOpportunities);
+			new AwardedOpportunities(newlyAwardedOpportunities.getRecords()).upsertContractToServiceNow();
 		}
-	}
-
-	public static void upsertContractOnNewAwardedOpportunities(AwardedOpportunities awardedOpportunities){
-		for (Opportunity opportunity:awardedOpportunities.getRecords()){
-			if(
-				opportunity.New_Or_Renewal__c == 'New' &&
-				String.isBlank(opportunity.ContractServiceNowUrl__c)
-			){
-				DML.enqueueJob(new ServiceNowUploadContractsQueueable(opportunity));
-				Logger.info('Contract is created in ServiceNow for this Opportunity', opportunity).addTag('Opportunity trigger handler service');
-				Logger.resumeSaving();
-			} else {
-				Logger.info('Contract is not created is ServiceNow for this Opportunity', opportunity).addTag('Opportunity trigger handler service');
-				Logger.info('New or renewal: ' + opportunity.New_Or_Renewal__c).addTag('Opportunity trigger handler service');
-				Logger.info('Service Now contract url: ' + opportunity.ContractServiceNowUrl__c).addTag('Opportunity trigger handler service');
-				Logger.resumeSaving();
-			}
-		}
-		Logger.saveLog();
-		Logger.resumeSaving();
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
+++ b/force-app/classes/processes/UpsertContractOnAwardedOpportunities.cls
@@ -5,7 +5,7 @@ public with sharing class UpsertContractOnAwardedOpportunities implements Trigge
 
 		AwardedOpportunities newlyAwardedOpportunities = new AwardedOpportunities(newOpportunities, oldOpportunities);
 		newlyAwardedOpportunities.filterByMatchingOwnerCountry();
-		newlyAwardedOpportunities.getNewOpportunitiesWithNoContractInServiceNow();
+		newlyAwardedOpportunities.filterNewOpportunitiesWithoutContracts();
 		if (!newlyAwardedOpportunities.isEmpty()) {
 			new AwardedOpportunities(newlyAwardedOpportunities.getRecords()).upsertContractToServiceNow();
 		}

--- a/force-app/classes/processes/UpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/UpsertContractOnNavisionChange.cls
@@ -5,7 +5,7 @@ public with sharing class UpsertContractOnNavisionChange implements TriggerActio
 		NavisionAccounts navisionAccountsWithCountryChange = new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts);
 		if (navisionAccountsWithCountryChange.getAccounts().isEmpty()) return;
 
-		AwardedOpportunities awardedOpportunities = new AwardedOpportunities(
+		AwardedOpportunities awardedOpportunitiesWithNoContract = new AwardedOpportunities(
 			[
 				SELECT Id, AccountId, OwnerId, StageName, New_or_Renewal__c, ContractServiceNowUrl__c,
 						Owner_Country__c, Account.Navision_Customer_NO__c,
@@ -13,11 +13,12 @@ public with sharing class UpsertContractOnNavisionChange implements TriggerActio
 						Account.Navision_Customer_DK__c
 				FROM Opportunity
 				WHERE StageName = :Opportunities.AWARDED
+				AND IsContractSent__c=FALSE
 				AND AccountId IN :navisionAccountsWithCountryChange.getAccountIds()
 			]
 		);
-		awardedOpportunities.parentAccountsByIds=new Map<Id, Account>(newAccounts);
-		awardedOpportunities.filterByMatchingOwnerCountry().
+		awardedOpportunitiesWithNoContract.parentAccountsByIds=new Map<Id, Account>(newAccounts);
+		awardedOpportunitiesWithNoContract.filterByMatchingOwnerCountry().
 				     		 filterNewOpportunitiesWithoutContracts().
 							 upsertContractToServiceNow();
 	}

--- a/force-app/classes/processes/UpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/UpsertContractOnNavisionChange.cls
@@ -1,0 +1,24 @@
+public with sharing class UpsertContractOnNavisionChange implements TriggerAction.AfterUpdate {
+	public void afterUpdate(List<Account> newAccounts, List<Account> oldAccounts) {
+		Logger.debug('UpsertContractOnNavisionChange - After Update');
+
+		NavisionAccounts navisionAccountsWithCountryChange = new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts);
+		if (navisionAccountsWithCountryChange.getAccounts().isEmpty()) return;
+
+		List<Opportunity> awardedOpportunities = [
+				SELECT Id, AccountId, OwnerId, StageName, New_or_Renewal__c, ContractServiceNowUrl__c,
+						Owner.Country, Account.Navision_Customer_NO__c,
+						Account.Navision_Customer_SE__c,
+						Account.Navision_Customer_DK__c
+				FROM Opportunity
+				WHERE StageName = :Opportunities.AWARDED
+				AND AccountId IN :navisionAccountsWithCountryChange.getAccountIds()
+		];
+		if (awardedOpportunities.isEmpty()) return;
+
+		new AwardedOpportunities(awardedOpportunities)
+				.filterByMatchingOwnerCountry()
+				.filterNewOpportunitiesWithoutContracts()
+				.upsertContractToServiceNow();
+	}
+}

--- a/force-app/classes/processes/UpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/UpsertContractOnNavisionChange.cls
@@ -17,9 +17,15 @@ public with sharing class UpsertContractOnNavisionChange implements TriggerActio
 				AND AccountId IN :navisionAccountsWithCountryChange.getAccountIds()
 			]
 		);
+		if (awardedOpportunitiesWithNoContract.isEmpty()) return;
+
 		awardedOpportunitiesWithNoContract.parentAccountsByIds=new Map<Id, Account>(newAccounts);
-		awardedOpportunitiesWithNoContract.filterByMatchingOwnerCountry().
-				     		 filterNewOpportunitiesWithoutContracts().
-							 upsertContractToServiceNow();
+		awardedOpportunitiesWithNoContract
+				.filterByMatchingOwnerCountry()
+				.filterNewOpportunitiesWithoutContracts();
+
+		if (!awardedOpportunitiesWithNoContract.isEmpty()){
+			awardedOpportunitiesWithNoContract.upsertContractToServiceNow();
+		}
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/UpsertContractOnNavisionChange.cls
@@ -5,20 +5,20 @@ public with sharing class UpsertContractOnNavisionChange implements TriggerActio
 		NavisionAccounts navisionAccountsWithCountryChange = new NavisionAccounts(newAccounts).filterAccountsWithNavisionCountryPositiveChange(oldAccounts);
 		if (navisionAccountsWithCountryChange.getAccounts().isEmpty()) return;
 
-		List<Opportunity> awardedOpportunities = [
+		AwardedOpportunities awardedOpportunities = new AwardedOpportunities(
+			[
 				SELECT Id, AccountId, OwnerId, StageName, New_or_Renewal__c, ContractServiceNowUrl__c,
-						Owner.Country, Account.Navision_Customer_NO__c,
+						Owner_Country__c, Account.Navision_Customer_NO__c,
 						Account.Navision_Customer_SE__c,
 						Account.Navision_Customer_DK__c
 				FROM Opportunity
 				WHERE StageName = :Opportunities.AWARDED
 				AND AccountId IN :navisionAccountsWithCountryChange.getAccountIds()
-		];
-		if (awardedOpportunities.isEmpty()) return;
-
-		new AwardedOpportunities(awardedOpportunities)
-				.filterByMatchingOwnerCountry()
-				.filterNewOpportunitiesWithoutContracts()
-				.upsertContractToServiceNow();
+			]
+		);
+		awardedOpportunities.parentAccountsByIds=new Map<Id, Account>(newAccounts);
+		awardedOpportunities.filterByMatchingOwnerCountry().
+				     		 filterNewOpportunitiesWithoutContracts().
+							 upsertContractToServiceNow();
 	}
 }

--- a/force-app/classes/processes/UpsertContractOnNavisionChange.cls-meta.xml
+++ b/force-app/classes/processes/UpsertContractOnNavisionChange.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>63.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls
@@ -11,6 +11,9 @@ public with sharing class TestUpsertContractOnNavisionChange {
 		List<Opportunity> awardedOpportunities = TestDataFactory.createOpportunities(2, true,false);
 		awardedOpportunities[0].StageName = Opportunities.AWARDED;
 		awardedOpportunities[1].StageName = Opportunities.AWARDED;
+		awardedOpportunities[0].New_or_Renewal__c='New';
+		awardedOpportunities[1].New_or_Renewal__c='New';
+
 		MetadataTriggerHandler.bypass('UpsertContractOnAwardedOpportunities');
 		System.runAs(new User(Id=UserInfo.getUserId())){
 			Assert.isTrue(FeatureManagement.checkPermission('ServiceNowContractUpsertTesting'),'ServiceNowContractUpsertTesting custom permission should be assigned');

--- a/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls
@@ -1,0 +1,40 @@
+@IsTest
+public with sharing class TestUpsertContractOnNavisionChange {
+
+	@IsTest
+	static void navisionCustomerUpdatesShouldTriggerContractCreationForAwardedOpportunitiesWithNoContract(){
+		DML.isMockDML=true;
+		System.runAs(new User(Id=UserInfo.getUserId())) {
+			TestingUtils.activateCustomPermission(UserInfo.getUserId(), 'ServiceNowContractUpsertTesting');
+		}
+
+		List<Opportunity> awardedOpportunities = TestDataFactory.createOpportunities(2, true,false);
+		awardedOpportunities[0].StageName = Opportunities.AWARDED;
+		awardedOpportunities[1].StageName = Opportunities.AWARDED;
+		MetadataTriggerHandler.bypass('UpsertContractOnAwardedOpportunities');
+		System.runAs(new User(Id=UserInfo.getUserId())){
+			Assert.isTrue(FeatureManagement.checkPermission('ServiceNowContractUpsertTesting'),'ServiceNowContractUpsertTesting custom permission should be assigned');
+			update awardedOpportunities;
+		}
+		update new User(
+				Id=UserInfo.getUserId(),
+				Country='Norway'
+		);
+		List<Account> oldAccounts = new List<Account>{
+				new Account(Id=awardedOpportunities[0].AccountId),
+				new Account(Id=awardedOpportunities[1].AccountId)
+		};
+		List<Account> newAccounts = new List<Account>{
+				new Account(Id=awardedOpportunities[0].AccountId, Navision_Customer_NO__c=true),
+				new Account(Id=awardedOpportunities[1].AccountId, Navision_Customer_SE__c=true)
+		};
+		Test.startTest();
+		UpsertContractOnNavisionChange upsertContractOnNavisionChange = new UpsertContractOnNavisionChange();
+		upsertContractOnNavisionChange.afterUpdate(newAccounts,oldAccounts);
+		Test.stopTest();
+
+		Assert.isFalse(DML.enqueuedJobs.isEmpty(),'1 Queueable job should be queued');
+		Assert.isInstanceOfType(DML.enqueuedJobs[0],ServiceNowUploadContractsQueueable.class, 'ServiceNowUploadContractsQueueable should be queued');
+	}
+
+}

--- a/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls
+++ b/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls
@@ -39,5 +39,4 @@ public with sharing class TestUpsertContractOnNavisionChange {
 		Assert.isFalse(DML.enqueuedJobs.isEmpty(),'1 Queueable job should be queued');
 		Assert.isInstanceOfType(DML.enqueuedJobs[0],ServiceNowUploadContractsQueueable.class, 'ServiceNowUploadContractsQueueable should be queued');
 	}
-
 }

--- a/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls-meta.xml
+++ b/force-app/classes/processes/tests/TestUpsertContractOnNavisionChange.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>63.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/force-app/classes/utils/TestingUtils.cls
+++ b/force-app/classes/utils/TestingUtils.cls
@@ -1,3 +1,4 @@
+@IsTest
 public with sharing class TestingUtils {
 
 	/**

--- a/force-app/classes/utils/TestingUtils.cls
+++ b/force-app/classes/utils/TestingUtils.cls
@@ -1,0 +1,30 @@
+public with sharing class TestingUtils {
+
+	/**
+	 * @description: Needed because SF doesn't support assigning existing Permission Sets in Test Context (Custom permissions are not calculated wrt. running user sharing access)
+	 * See https://www.jamessimone.net/blog/joys-of-apex/testing-custom-permissions/
+	 */
+	public static void activateCustomPermission(Id userId, String permissionName){
+		PermissionSet serviceNowContractUpsertTesting = new PermissionSet(
+			Name='DummyPSfortesting',
+			Label='Dummy PS for testing'
+		);
+		insert serviceNowContractUpsertTesting;
+
+		SetupEntityAccess setupEntityAccess = new SetupEntityAccess(
+				ParentId=serviceNowContractUpsertTesting.Id,
+				SetupEntityId=[
+						SELECT Id
+						FROM CustomPermission
+						WHERE DeveloperName=:permissionName
+						LIMIT 1
+				].Id
+		);
+		PermissionSetAssignment permissionSetAssignment=new PermissionSetAssignment(
+				AssigneeId=userId,
+				PermissionSetId=serviceNowContractUpsertTesting.Id
+
+		);
+		insert new List<SObject>{setupEntityAccess, permissionSetAssignment};
+	}
+}

--- a/force-app/classes/utils/TestingUtils.cls-meta.xml
+++ b/force-app/classes/utils/TestingUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+	<apiVersion>63.0</apiVersion>
+	<status>Active</status>
+</ApexClass>

--- a/force-app/customMetadata/SObjectTriggerSettings/sObject_Trigger_Setting.Account.md-meta.xml
+++ b/force-app/customMetadata/SObjectTriggerSettings/sObject_Trigger_Setting.Account.md-meta.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Account</label>
+    <protected>false</protected>
+    <values>
+        <field>Bypass_Execution__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Bypass_Permission__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Object_API_Name__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>Object_Namespace__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Required_Permission__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>TriggerRecord_Class_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/customMetadata/TriggerActions/Trigger_Action.UpsertContractOnNavisionChange.md-meta.xml
+++ b/force-app/customMetadata/TriggerActions/Trigger_Action.UpsertContractOnNavisionChange.md-meta.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Upsert Contract On Navision Change</label>
+    <protected>false</protected>
+    <values>
+        <field>After_Delete__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>After_Insert__c</field>
+        <value xsi:type="xsd:string">Account</value>
+    </values>
+    <values>
+        <field>After_Undelete__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>After_Update__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Allow_Flow_Recursion__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Apex_Class_Name__c</field>
+        <value xsi:type="xsd:string">UpsertContractOnNavisionChange</value>
+    </values>
+    <values>
+        <field>Before_Delete__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Before_Insert__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Before_Update__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Bypass_Execution__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Bypass_Permission__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">When an Account is registered as a Navision [NO/SE/DK] Customer --&gt; upsert contract towards ServiceNow for all Awarded Opportunities for that Country that have no contract</value>
+    </values>
+    <values>
+        <field>Entry_Criteria__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Flow_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Order__c</field>
+        <value xsi:type="xsd:double">1.0</value>
+    </values>
+    <values>
+        <field>Required_Permission__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/triggers/AccountTrigger.trigger
+++ b/force-app/triggers/AccountTrigger.trigger
@@ -1,0 +1,3 @@
+trigger AccountTrigger on Account (after update) {
+   new MetadataTriggerHandler().run();
+}

--- a/force-app/triggers/AccountTrigger.trigger-meta.xml
+++ b/force-app/triggers/AccountTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>63.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -27,7 +27,7 @@
                 },
                 {
                     "package": "platform-base",
-                    "versionNumber": "1.0.0.LATEST"
+                    "versionNumber": "1.1.0.LATEST"
                 }
             ]
         }


### PR DESCRIPTION
https://soprasteriaadc.atlassian.net/jira/software/projects/CIS/boards/150?selectedIssue=CIS-111

Legge til støtte for ny request mot SN når en kunde endrer status til “active in Navision” i stage 5 - awarded. Når f.eks. en kunde blir satt til “active in Navision” for Norge, så skal ny request mot ServiceNow bli sendt for alle Opportunities der eier av Opportunity = Norway og som har status = ‘stage 5 - awarded’ 

Også håndtere corner case hvor en Account har 

først blitt satt til “active in Navision”

deretter blitt satt til “inactive in Navision” (f.eks. Blocked Account)

og deretter blitt satt tilbake til “active in Navision”

Da skal kun Opportunities som ikke har sendt kontrakt også bli sendt mot ServiceNow. 